### PR TITLE
j4lte: fix PAYLOAD_ENTRY

### DIFF
--- a/board/Kconfig
+++ b/board/Kconfig
@@ -83,7 +83,7 @@ menu "Device Specific Addresses"
 		default 0x090000000 if SAMSUNG_STARLTE
 		default 0x090000000 if SAMSUNG_X1S
 		default 0x090000000 if SAMSUNG_J5LTE
-		default 0x040000000 if SAMSUNG_J4LTE
+		default 0x050000000 if SAMSUNG_J4LTE
 
 
 	config FRAMEBUFFER_BASE


### PR DESCRIPTION
0x40008000 is used by kernel, and can be rewrited by new payload