### PR TITLE
board: samsung: Fix compile issues due to missing headers

### DIFF
--- a/board/samsung/board-c1s.c
+++ b/board/samsung/board-c1s.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2024, Ivaylo Ivanov <ivo.ivanov.ivanov1@gmail.com>
  */
 #include <board.h>
+#include <drivers/framework.h>
+#include <lib/simplefb.h>
 
 #define DECON_F_BASE		0x19050000
 #define HW_SW_TRIG_CONTROL	0x70

--- a/board/samsung/board-gta4xl.c
+++ b/board/samsung/board-gta4xl.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2024, Ivaylo Ivanov <ivo.ivanov.ivanov1@gmail.com>
  */
 #include <board.h>
+#include <drivers/framework.h>
+#include <lib/simplefb.h>
 
 #define DECON_F_BASE		0x148b0000
 #define HW_SW_TRIG_CONTROL	0x70

--- a/board/samsung/board-j4lte.c
+++ b/board/samsung/board-j4lte.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2024, Ivaylo Ivanov <ivo.ivanov.ivanov1@gmail.com>
  */
 #include <board.h>
+#include <drivers/framework.h>
+#include <lib/simplefb.h>
 
 #define DECON_F_BASE		0x14830000
 #define HW_SW_TRIG_CONTROL	0x70

--- a/board/samsung/board-jackpotlte.c
+++ b/board/samsung/board-jackpotlte.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2024, Ivaylo Ivanov <ivo.ivanov.ivanov1@gmail.com>
  */
 #include <board.h>
+#include <drivers/framework.h>
+#include <lib/simplefb.h>
 
 #define DECON_F_BASE		0x14860000
 #define HW_SW_TRIG_CONTROL	0x70

--- a/board/samsung/board-noblelte.c
+++ b/board/samsung/board-noblelte.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2024, Ivaylo Ivanov <ivo.ivanov.ivanov1@gmail.com>
  */
 #include <board.h>
+#include <drivers/framework.h>
+#include <lib/simplefb.h>
 
 #define DECON_F_BASE		0x13930000
 #define HW_SW_TRIG_CONTROL	0x6b0

--- a/board/samsung/board-starlte.c
+++ b/board/samsung/board-starlte.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2024, Ivaylo Ivanov <ivo.ivanov.ivanov1@gmail.com>
  */
 #include <board.h>
+#include <drivers/framework.h>
+#include <lib/simplefb.h>
 
 #define DECON_F_BASE		0x16030000
 #define HW_SW_TRIG_CONTROL	0x70

--- a/board/samsung/board-x1s.c
+++ b/board/samsung/board-x1s.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2024, Ivaylo Ivanov <ivo.ivanov.ivanov1@gmail.com>
  */
 #include <board.h>
+#include <drivers/framework.h>
+#include <lib/simplefb.h>
 
 #define DECON_F_BASE		0x19050000
 #define HW_SW_TRIG_CONTROL	0x70

--- a/board/samsung/board-zeroflte.c
+++ b/board/samsung/board-zeroflte.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2024, Ivaylo Ivanov <ivo.ivanov.ivanov1@gmail.com>
  */
 #include <board.h>
+#include <drivers/framework.h>
+#include <lib/simplefb.h>
 
 #define DECON_F_BASE		0x13930000
 #define HW_SW_TRIG_CONTROL	0x6b0


### PR DESCRIPTION
The board files for all boards except for dreamlte and j4lte are missing drivers/framework.h and lib/simplefb.h headers. This causes build failures on all targets except for dreamlte and j4lte.

This commit includes said headers.