### PR TITLE
gta4xl: Set CONFIG_RAMDISK_ENTRY

### DIFF
--- a/board/Kconfig
+++ b/board/Kconfig
@@ -120,6 +120,7 @@ menu "Device Specific Addresses"
 		default 0x084000000 if SAMSUNG_G0S
 		default 0x084000000 if SAMSUNG_X1S
 		default 0x084000000 if SAMSUNG_R8S
+		default 0x084000000 if SAMSUNG_GTA4XL
 
 	config FRAMEBUFFER_BASE
 		hex "Framebuffer Base Address (for SimpleFB)"


### PR DESCRIPTION
Needed by Linux to load a ramdisk