### PR TITLE
check-lxdialog: Fix lxdialog check on new compilers

### DIFF
--- a/scripts/kconfig/lxdialog/check-lxdialog.sh
+++ b/scripts/kconfig/lxdialog/check-lxdialog.sh
@@ -40,7 +40,7 @@ trap "rm -f $tmp" 0 1 2 3 15
 check() {
         $cc -xc - -o $tmp 2>/dev/null <<'EOF'
 #include CURSES_LOC
-main() {}
+int main() {}
 EOF
 	if [ $? != 0 ]; then
 	    echo " *** Unable to find the ncurses libraries or the"       1>&2


### PR DESCRIPTION
This causes menuconfig to not work, as without the function return type, gcc will produce a warning.

Fixes this error:
```
$ make menuconfig
  HOSTCC  scripts/kconfig/conf.o
 *** Unable to find the ncurses libraries or the
 *** required header files.
 *** 'make menuconfig' requires the ncurses libraries.
 ***
 *** Install ncurses (ncurses-devel) and try again.
 ***
make[1]: *** [/home/igor/phones/z3s/uniLoader/scripts/kconfig/Makefile:219: scripts/kconfig/dochecklxdialog] Error 1
```