### PR TITLE
README: change building example architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The currently supported architectures are ARMV7 and AARCH64.</br>
     ```sh
     cd uniLoader
     ```
-4. Place your kernel and device tree blobs under the `blob/` directory.
+4. Place your kernel, device tree blob and ramdisk under the `blob/` directory.
 
 ### Make Syntax
 ```sh
@@ -31,9 +31,10 @@ git clone https://github.com/ivoszbg/uniLoader
 cd uniLoader
 cp /home/user/linux/arch/arm64/boot/Image blob/Image
 cp /home/user/linux/arch/arm64/boot/dts/exynos/exynos8895-dreamlte.dtb blob/dtb
-make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -j4 dreamlte_defconfig
-make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -j4
+make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu- -j4 dreamlte_defconfig
+make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu- -j4
 ```
+You will also need to copy the ramdisk into `blob/ramdisk`.
 
 ### Usage
 


### PR DESCRIPTION
It is no longer arm64 - also clarify that blob/ramdisk is needed now