### PR TITLE
soc: fix Kconfig warning

### DIFF
--- a/soc/Kconfig
+++ b/soc/Kconfig
@@ -123,7 +123,6 @@ config QUALCOMM
 
 	config MT6785
 		bool "Support for Mediatek MT6785"
-		default n
 		select MEDIATEK
 		help
 		  Say Y if your device uses Mediatek MT6785 SoC


### PR DESCRIPTION
Kconfig gives this warning:
```
soc/Kconfig:126:warning: defaults for choice value not supported
```