### PR TITLE
main: Fix duplicate drivers_init call

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -32,7 +32,7 @@ void main(void* dt, void* kernel, void* ramdisk)
 	printk(KERN_INFO, "passed board initialization\n");
 	printk(KERN_INFO, "welcome to uniLoader %s on %s\n", VER_TAG, board_ops.name);
 
-	INITCALL(board_ops.ops.drivers_init);
+	INITCALL(board_ops.ops.late_init);
 
 #ifdef CONFIG_LIBFDT
 	ret = ramdisk_handler_patch_dtb(dt, &fdt_buf, sizeof(fdt_buf));


### PR DESCRIPTION
Commit https://github.com/ivoszbg/uniLoader/commit/7993348878f9252da96ac5096d2dbb3727b328bc accidentally replaced the late_init call with a duplicate drivers_init call when converting the initcall logic to use the new INITCALL macro.

This causes drivers to be probed twice during boot. For the simplefb driver, this results in the framebuffer being cleared after the boot logo has already been printed, since simplefb_probe() calls clean_fbmem() unconditionally.