### PR TITLE
arch: zero BSS section during early boot

### DIFF
--- a/arch/aarch64/start.S
+++ b/arch/aarch64/start.S
@@ -32,6 +32,18 @@ ENTRY(_start)
 	/* Set up the stack pointer (SP) */
 	mov sp, x0
 
+	/* Zero BSS section */
+	adrp    x0, __bss_start
+	add     x0, x0, #:lo12:__bss_start
+	adrp    x1, __bss_end
+	add     x1, x1, #:lo12:__bss_end
+1:
+	cmp     x0, x1
+	b.ge    2f
+	str     xzr, [x0], #8
+	b       1b
+2:
+
 	/* Fall through */
 	adrp    x0, dtb             /* Load page of dtb */
 	add     x0, x0, #:lo12:dtb  /* Add offset within the page */

--- a/arch/arm/start.S
+++ b/arch/arm/start.S
@@ -20,6 +20,17 @@ ENTRY(_start)
 
 	ldr sp, =__stack_top
 
+	/* Zero BSS section */
+	ldr r0, =__bss_start
+	ldr r1, =__bss_end
+	mov r2, #0
+1:
+	cmp r0, r1
+	bge 2f
+	str r2, [r0], #4
+	b 1b
+2:
+
 	/* main(void* dt, void* kernel, void* ramdisk) */
 	ldr r0, =_dt_start		@ Load address of dtb into r0
 	ldr r1, =_kernel_start		@ Load address of kernel into r1


### PR DESCRIPTION
The C runtime requires that uninitialized global variables are zero. In a bare-metal environment, memory contents are undefined at startup and the BSS section is not automatically cleared, so we must zero out this entire section ourselves.

Without this, static variables contain garbage values, leading to unpredictable behavior. For example, the simplefb driver uses a static variable to track the current print position, which resulted in text being drawn at random locations on the screen.