### PR TITLE
Regenerate stale linker.lds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,7 @@ ifdef CONFIG_RAMDISK_NO_COPY
 	  cmd_cpp_lds += -DRAMDISK_SIZE=$(shell stat -c%s $(RAMDISK_PATH))
 endif
 
-arch/$(ARCH)/linker.lds: arch/$(ARCH)/linker.lds.S $(linker-script-deps)
+arch/$(ARCH)/linker.lds: arch/$(ARCH)/linker.lds.S $(linker-script-deps) FORCE
 	$(call if_changed,cpp_lds)
 
 #


### PR DESCRIPTION
This forcefully regenerates linker.lds script when gone stale.