### PR TITLE
lib: nanoprintf: let the compiler use division instructions for divmod

### DIFF
--- a/include/lib/nanoprintf.h
+++ b/include/lib/nanoprintf.h
@@ -505,14 +505,8 @@ static int npf_parse_format_spec(char const *format, npf_format_spec_t *out_spec
 }
 
 static npf_uint_t divmod(npf_uint_t val, uint_fast8_t base, npf_uint_t *rem) {
-  npf_uint_t quotient = 0;
-  npf_uint_t remainder = val;
-  while (remainder >= base) {
-    remainder -= base;
-    quotient++;
-  }
-  *rem = remainder;
-  return quotient;
+  *rem = val % base;
+  return val / base;
 }
 
 static NPF_NOINLINE int npf_utoa_rev(


### PR DESCRIPTION
Due to divmod performing division by subtracting in a linear loop, it's *really* slow. When performing division with larger numbers (like 32-bit addresses), it goes thru massive amounts of iterations and causes a stall-like appearance.

Instead, let the compiler handle it by using cpu instructions like UDIV/MSUB for armv8.

Fixes #86.