### PR TITLE
Fix bug where initial ramdisk is not passed to kernel

### DIFF
--- a/include/main/boot-fdt.h
+++ b/include/main/boot-fdt.h
@@ -6,6 +6,6 @@
 #ifndef BOOT_FDT_H_
 #define BOOT_FDT_H_
 
-void patch_dtb(void* dt);
+void patch_dtb(void** dt);
 
 #endif // BOOT_FDT_H_

--- a/main/boot-fdt.c
+++ b/main/boot-fdt.c
@@ -8,13 +8,13 @@
 
 static char fdt_buf[CONFIG_FDT_BUF_SIZE];
 
-void patch_dtb(void* dt)
+void patch_dtb(void** dt)
 {
 	int ret;
 
-	ret = ramdisk_handler_patch_dtb(dt, &fdt_buf, sizeof(fdt_buf));
+	ret = ramdisk_handler_patch_dtb(*dt, &fdt_buf, sizeof(fdt_buf));
 	if (ret != 0)
 		printk(KERN_ERR, "failed to patch dtb\n");
 	else
-		dt = &fdt_buf;
+		*dt = &fdt_buf;
 }

--- a/main/boot.c
+++ b/main/boot.c
@@ -12,7 +12,7 @@
 void boot_kernel(void* dt, void* kernel, void* ramdisk)
 {
 #ifdef CONFIG_LIBFDT
-	patch_dtb(dt);
+	patch_dtb(&dt);
 #endif
 
 	printk(KERN_INFO, "Booting kernel...\n");


### PR DESCRIPTION
This PR fixes a bug where the initial ramdisk is not passed to the kernel.

Since the printk issue with numeric values was fixed, I was able to track down *this* bug, and it turns out it's a really simple problem.

At the call to patch_dtb in boot_kernel, the address to the DTB is passed, and the chain of functions called after this all change this initial address to the modified DTB back up the chain. The new address would propagate all the way back to patch_fdt, but it could not propagate back to boot_kernel due to only the address of the DTB being passed, rather than the address to the address.

The fix is to pass the address to the address of the DTB from boot_kernel to patch_dtb, rather than just the address of the DTB, in order to allow the address in boot_kernel to be overwritten with the address to the new DTB and passed to the kernel successfully.

Tested and working on lucky7.