### PR TITLE
simplefb: Fix write order of pixels for FB_FORMAT_BGRA8888, introduce FB_FORMAT_ABGR8888 and fix J4LTE's fb format.

### DIFF
--- a/board/itel/board-p682lpn.c
+++ b/board/itel/board-p682lpn.c
@@ -87,7 +87,7 @@ int p682lpn_init(void)
 
 #ifdef CONFIG_SIMPLE_FB
 static struct video_info p682lpn_fb = {
-	.format = FB_FORMAT_BGRA8888,
+	.format = FB_FORMAT_ABGR8888,
 	.width = 720,
 	.height = 1640,
 	.stride = 4,

--- a/board/samsung/board-j4lte.c
+++ b/board/samsung/board-j4lte.c
@@ -20,7 +20,7 @@ int j4lte_init(void)
 
 #ifdef CONFIG_SIMPLE_FB
 static struct video_info j4lte_fb = {
-	.format = FB_FORMAT_BGRA8888,
+	.format = FB_FORMAT_ARGB8888,
 	.width = 720,
 	.height = 1280,
 	.stride = 4,

--- a/board/sony/board-vita.c
+++ b/board/sony/board-vita.c
@@ -10,7 +10,7 @@
 
 #ifdef CONFIG_SIMPLE_FB
 static struct video_info vita12k_fb = {
-	.format = FB_FORMAT_BGRA8888,
+	.format = FB_FORMAT_ABGR8888,
 	.width = 960,
 	.height = 544,
 	.stride = 4,

--- a/include/lib/simplefb.h
+++ b/include/lib/simplefb.h
@@ -20,6 +20,7 @@ typedef struct _color {
 typedef enum {
 	FB_FORMAT_RGB888,
 	FB_FORMAT_ARGB8888,
+	FB_FORMAT_ABGR8888,
 	FB_FORMAT_BGRA8888,
 } video_format;
 

--- a/lib/simplefb/simplefb.c
+++ b/lib/simplefb/simplefb.c
@@ -32,6 +32,12 @@ static void draw_pixel(volatile char *fb, int x, int y, int width, int stride,
 		*(fb + location + 2) = c.r;
 		*(fb + location + 3) = c.a;
 		break;
+	case FB_FORMAT_ABGR8888:
+		*(fb + location) = c.r;
+		*(fb + location + 1) = c.g;
+		*(fb + location + 2) = c.b;
+		*(fb + location + 3) = c.a;
+		break;
 	case FB_FORMAT_BGRA8888:
 		*(fb + location) = c.a;
 		*(fb + location + 1) = c.r;

--- a/lib/simplefb/simplefb.c
+++ b/lib/simplefb/simplefb.c
@@ -33,10 +33,10 @@ static void draw_pixel(volatile char *fb, int x, int y, int width, int stride,
 		*(fb + location + 3) = c.a;
 		break;
 	case FB_FORMAT_BGRA8888:
-		*(fb + location) = c.r;
-		*(fb + location + 1) = c.g;
-		*(fb + location + 2) = c.b;
-		*(fb + location + 3) = c.a;
+		*(fb + location) = c.a;
+		*(fb + location + 1) = c.r;
+		*(fb + location + 2) = c.g;
+		*(fb + location + 3) = c.b;
 		break;
 	case FB_FORMAT_RGB888:
 		*(fb + location) = c.b;


### PR DESCRIPTION
Fixes an issue where pixel data is stored as ABGR, not BGRA

addresses issue https://github.com/ivoszbg/uniLoader/issues/101